### PR TITLE
Add Known Answer Tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Multimixer-128
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run Known Answer Tests
+      run: cargo test --lib
+    - name: Run Examples
+      run: cargo run --example multimixer_128

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ crunchy = "0.2.2"
 
 [dev-dependencies]
 rand = "0.8.5"
+hex = "0.4.3"
 criterion = "0.5.1"
 
 [lib]

--- a/examples/multimixer_128.rs
+++ b/examples/multimixer_128.rs
@@ -1,0 +1,21 @@
+use multimixer_128::{multimixer_128, BLOCK_SIZE, DIGEST_SIZE};
+use rand::{thread_rng, RngCore};
+
+fn main() {
+    const BLOCKS: usize = 1;
+    const MLEN: usize = BLOCK_SIZE * BLOCKS;
+
+    let mut key = [0u8; MLEN];
+    let mut msg = [0u8; MLEN];
+    let mut dig = [0u8; DIGEST_SIZE];
+
+    let mut rng = thread_rng();
+    rng.fill_bytes(&mut key);
+    rng.fill_bytes(&mut msg);
+
+    multimixer_128(&key, &msg, &mut dig);
+
+    println!("Key     = {}", hex::encode(&key));
+    println!("Message = {}", hex::encode(&msg));
+    println!("Digest  = {}", hex::encode(&dig));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod multimixer_128;
+mod test_multimixer_128;
 
 #[cfg(feature = "internal")]
 pub use multimixer_128::{f_128, multimixer_128, BLOCK_SIZE, DIGEST_SIZE};

--- a/src/multimixer_128.rs
+++ b/src/multimixer_128.rs
@@ -14,15 +14,28 @@ pub fn f_128(x: &[u32; 8]) -> [u64; 8] {
     let mut u = [0u32; 4];
     let mut v = [0u32; 4];
 
+    // Read definition 9 ( on page 11 ) of specification https://ia.cr/2023/1357,
+    // which provides an alternative definition of F-128.
+    //
+    // u <- Nα · x
+    // s.t. Nα <- circ(1, 1, 1, 0) <- [1, 1, 1, 0]
+    //                                [0, 1, 1, 1]
+    //                                [1, 0, 1, 1]
+    //                                [1, 1, 0, 1]
     u[0] = x[0].wrapping_add(x[1]).wrapping_add(x[2]);
     u[1] = x[1].wrapping_add(x[2]).wrapping_add(x[3]);
     u[2] = x[2].wrapping_add(x[3]).wrapping_add(x[0]);
     u[3] = x[3].wrapping_add(x[0]).wrapping_add(x[1]);
 
-    v[0] = x[4].wrapping_add(x[5]).wrapping_add(x[6]);
-    v[1] = x[5].wrapping_add(x[6]).wrapping_add(x[7]);
-    v[2] = x[6].wrapping_add(x[7]).wrapping_add(x[4]);
-    v[3] = x[7].wrapping_add(x[4]).wrapping_add(x[5]);
+    // v <- Nβ · y
+    // s.t. Nβ <- circ(0, 1, 1, 1) <- [0, 1, 1, 1]
+    //                                [1, 0, 1, 1]
+    //                                [1, 1, 0, 1]
+    //                                [1, 1, 1, 0]
+    v[0] = x[5].wrapping_add(x[6]).wrapping_add(x[7]);
+    v[1] = x[6].wrapping_add(x[7]).wrapping_add(x[4]);
+    v[2] = x[7].wrapping_add(x[4]).wrapping_add(x[5]);
+    v[3] = x[4].wrapping_add(x[5]).wrapping_add(x[6]);
 
     let mut z = [0u64; 8];
 

--- a/src/test_multimixer_128.rs
+++ b/src/test_multimixer_128.rs
@@ -1,0 +1,55 @@
+#![cfg(test)]
+
+use crate::multimixer_128::{multimixer_128, BLOCK_SIZE, DIGEST_SIZE};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+#[test]
+fn test_known_answer_tests() {
+    const FILE: &str = "./multimixer_128.kat";
+
+    let fd = File::open(FILE).unwrap();
+    let mut lines = BufReader::new(fd).lines();
+
+    while let Some(line) = lines.next() {
+        let mlen = line.unwrap().split(" = ").collect::<Vec<&str>>()[1]
+            .parse::<usize>()
+            .unwrap();
+        let key = hex::decode(
+            lines
+                .next()
+                .unwrap()
+                .unwrap()
+                .split(" = ")
+                .collect::<Vec<&str>>()[1],
+        )
+        .unwrap();
+        let msg = hex::decode(
+            lines
+                .next()
+                .unwrap()
+                .unwrap()
+                .split(" = ")
+                .collect::<Vec<&str>>()[1],
+        )
+        .unwrap();
+        let md = hex::decode(
+            lines
+                .next()
+                .unwrap()
+                .unwrap()
+                .split(" = ")
+                .collect::<Vec<&str>>()[1],
+        )
+        .unwrap();
+
+        assert!(mlen > 0);
+        assert!(mlen % BLOCK_SIZE == 0);
+        let mut computed_md = [0u8; DIGEST_SIZE];
+
+        multimixer_128(&key, &msg, &mut computed_md);
+        assert_eq!(md, computed_md);
+
+        lines.next(); // empty line, at end of each test case
+    }
+}


### PR DESCRIPTION
- [x] Add known answer tests for ensuring functional correctness and conformance of this implementation of Multimixer-128
- [x] Ensure that tests are also run on CI, using github actions

Run tests
```bash
cargo test --lib
```
> **Note** Known Answer Tests were generated by following instructions described in https://gist.github.com/itzmeanjan/a32eab0244af55eba2847c6472337535.