### PR TITLE
Make Internal Functions `const fn`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ crunchy = "=0.2.2"
 rand = "=0.8.5"
 hex = "=0.4.3"
 criterion = "=0.5.1"
+static_assertions = "1.1.0"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "loongarch64"))'.dev-dependencies]
 criterion-cycles-per-byte = {git = "https://github.com/itzmeanjan/criterion-cycles-per-byte", rev = "2dc25c6"}
@@ -31,4 +32,8 @@ bench = false
 [[bench]]
 name = "multimixer_128"
 harness = false
+required-features = ["internal"]
+
+[[example]]
+name = "f_128"
 required-features = ["internal"]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ Using $Multimixer_{128}$ hasher API is pretty straight-forward.
 multimixer-128 = { git = "https://github.com/itzmeanjan/multimixer-128" }
 # or
 multimixer-128 = "0.1.0"
+
+# In case you're also interested in using f_128, the public function of multimixer-128,
+# enable `internal` feature-gate of this crate.
+#
+# multimixer-128 = { version = "0.1.0", features = "internal" }
 ```
 
 2) Get non-zero, equal length key and message s.t. their byte length is a multiple of block size (= 32 -bytes), as input.
@@ -147,3 +152,6 @@ Key     = e02f28d290bd51df3b103396debe7f2ffc90b837588e37b13a7cc8cccce9fa11
 Message = 1511ad54daae3df6706e33d9953f5dff4eabb2da85ad1added1aba2e0b571397
 Digest  = d2324595d842cb028205c1f00328ba760d292a690452726d95728070ee7ff21e8e6af14b1e4c6d15404e709fd1fec952da3e3b7b3fe7d038fca793f3b4d7661a
 ```
+
+> **Note**
+Most of the internal functions of this library crate are implemented as `const fn` i.e. compile-time evaluable functions. That's why I also maintain another example [f_128.rs](./examples/f_128.rs) which demonstrates that property of this library using static assertions. Try executing the example program by issuing `$ cargo run --example f_128 --features="internal"` and you'll see it.

--- a/examples/f_128.rs
+++ b/examples/f_128.rs
@@ -1,0 +1,32 @@
+use multimixer_128::f_128;
+use static_assertions::const_assert;
+
+const fn eq_slice<const L: usize>(a: &[u64; L], b: &[u64; L]) -> bool {
+    let mut acc = false;
+    let mut idx = 0;
+
+    while idx < L {
+        acc |= (a[idx] ^ b[idx]) != 0;
+        idx += 1;
+    }
+
+    !acc
+}
+
+const fn main() {
+    const X: [u32; 8] = [0xff00ff00; 8];
+    const Y: [u64; 8] = f_128(&X);
+    const EXPECTED_Y: [u64; 8] = [
+        0xfe02fc02fe010000,
+        0xfe02fc02fe010000,
+        0xfe02fc02fe010000,
+        0xfe02fc02fe010000,
+        0xfa0ee81aee090000,
+        0xfa0ee81aee090000,
+        0xfa0ee81aee090000,
+        0xfa0ee81aee090000,
+    ];
+
+    // Must hold f_128(x) == y !
+    const_assert!(eq_slice(&Y, &EXPECTED_Y));
+}

--- a/src/multimixer_128.rs
+++ b/src/multimixer_128.rs
@@ -5,12 +5,17 @@ pub const BLOCK_SIZE: usize = 32;
 /// Message digest produced by Multimixer-128 is 64 -bytes wide.
 pub const DIGEST_SIZE: usize = BLOCK_SIZE * 2;
 
+// Number of u32 words, in input key/ message block (or chunk)
+const IN_WORD_COUNT: usize = BLOCK_SIZE / std::mem::size_of::<u32>();
+// Number of u64 words, in output digest block (or chunk)
+const OUT_WORD_COUNT: usize = DIGEST_SIZE / std::mem::size_of::<u64>();
+
 /// The public function of universal keyed hashing Multimixer, F-128
 ///
 /// Given eight 32 -bit words as input, this routine applies F-128 and returns eight 64 -bit words.
 /// This is an implementation of algorithm 2, in section 5 of paper https://ia.cr/2023/1357.
 #[inline(always)]
-pub fn f_128(x: &[u32; 8]) -> [u64; 8] {
+pub const fn f_128(x: &[u32; IN_WORD_COUNT]) -> [u64; OUT_WORD_COUNT] {
     let mut u = [0u32; 4];
     let mut v = [0u32; 4];
 
@@ -52,26 +57,35 @@ pub fn f_128(x: &[u32; 8]) -> [u64; 8] {
     z
 }
 
-/// Given 32*n -bytes as input, this routine can be used for parsing input bytes into message
-/// blocks of size 32 -bytes each s.t. n > 0.
+/// Given 32 -bytes as input, this routine can be used for parsing input bytes as eight 32 -bit
+/// little-endian unsigned integers.
 #[inline(always)]
-fn get_data_block(data: &[u8], blk: &mut [u32; 8]) {
-    debug_assert!((data.len() > 0) && (data.len() % BLOCK_SIZE == 0), "Input must be non-empty and byte length of it must be multiple of block size i.e. 32 -bytes !");
+const fn get_data_block(data: &[u8; BLOCK_SIZE]) -> [u32; IN_WORD_COUNT] {
+    const STEP: usize = std::mem::size_of::<u32>();
 
-    blk[0] = u32::from_le_bytes(data[0..4].try_into().unwrap());
-    blk[1] = u32::from_le_bytes(data[4..8].try_into().unwrap());
-    blk[2] = u32::from_le_bytes(data[8..12].try_into().unwrap());
-    blk[3] = u32::from_le_bytes(data[12..16].try_into().unwrap());
-    blk[4] = u32::from_le_bytes(data[16..20].try_into().unwrap());
-    blk[5] = u32::from_le_bytes(data[20..24].try_into().unwrap());
-    blk[6] = u32::from_le_bytes(data[24..28].try_into().unwrap());
-    blk[7] = u32::from_le_bytes(data[28..32].try_into().unwrap());
+    let mut off = 0;
+    let mut words = [0u32; 8];
+
+    while off < data.len() {
+        let word = ((data[off + 3] as u32) << 24)
+            ^ ((data[off + 2] as u32) << 16)
+            ^ ((data[off + 1] as u32) << 8)
+            ^ (data[off + 0] as u32);
+
+        words[off / STEP] = word;
+        off += STEP;
+    }
+
+    words
 }
 
 /// Given two message blocks of length 32 -bytes, this routine adds them by performing word-wise
 /// ( each word is of 32 -bits ) modulo addition ( modulo 2**32 ).
 #[inline(always)]
-fn add_blocks(blk_a: &[u32; 8], blk_b: &[u32; 8]) -> [u32; 8] {
+const fn add_blocks(
+    blk_a: &[u32; IN_WORD_COUNT],
+    blk_b: &[u32; IN_WORD_COUNT],
+) -> [u32; IN_WORD_COUNT] {
     let mut res = [0u32; 8];
 
     unroll! {
@@ -85,12 +99,19 @@ fn add_blocks(blk_a: &[u32; 8], blk_b: &[u32; 8]) -> [u32; 8] {
 /// Given 64 -bytes of input message block, this routine accumulates it into resulting digest of 64 -bytes,
 /// by performing word-wise ( each word is of 64 -bits ) modulo addition ( modulo 2**64 ).
 #[inline(always)]
-fn add_into_result(h: &mut [u64; 8], z: &[u64; 8]) {
+const fn add_with_result(
+    h: &[u64; OUT_WORD_COUNT],
+    z: &[u64; OUT_WORD_COUNT],
+) -> [u64; OUT_WORD_COUNT] {
+    let mut h_prime = [0u64; 8];
+
     unroll! {
         for i in 0..8 {
-            h[i] = h[i].wrapping_add(z[i]);
+            h_prime[i] = h[i].wrapping_add(z[i]);
         }
     }
+
+    h_prime
 }
 
 /// Given n -bytes key and message s.t. n > 0 and n is a multiple of block size ( = 32 ), this routine
@@ -100,28 +121,26 @@ fn add_into_result(h: &mut [u64; 8], z: &[u64; 8]) {
 /// This is an implementation of algorithm 1, in section 3 of paper https://ia.cr/2023/1357.
 #[inline(always)]
 pub fn multimixer_128(key: &[u8], msg: &[u8], dig: &mut [u8; DIGEST_SIZE]) {
-    debug_assert!(msg.len() > 0, "Message must be non-empty !");
     debug_assert!(
         key.len() == msg.len(),
         "Both key and message must be of equal byte length !"
     );
+    debug_assert!(msg.len() > 0, "Message must be non-empty !");
     debug_assert!(
         msg.len() % BLOCK_SIZE == 0,
         "Key/ Message byte length must be a multiple of block size i.e. 32 -bytes !"
     );
 
-    let mut key_blk = [0u32; 8]; // key block, 32 -bytes
-    let mut msg_blk = [0u32; 8]; // message block, 32 -bytes
     let mut h = [0u64; 8]; // digest block, 64 -bytes
 
     let mut off = 0;
     while off < msg.len() {
-        get_data_block(&key[off..], &mut key_blk);
-        get_data_block(&msg[off..], &mut msg_blk);
+        let key_blk = get_data_block(&key[off..(off + BLOCK_SIZE)].try_into().unwrap());
+        let msg_blk = get_data_block(&msg[off..(off + BLOCK_SIZE)].try_into().unwrap());
 
         let x = add_blocks(&key_blk, &msg_blk);
         let z = f_128(&x);
-        add_into_result(&mut h, &z);
+        h = add_with_result(&h, &z);
 
         off += BLOCK_SIZE;
     }

--- a/src/test_multimixer_128.rs
+++ b/src/test_multimixer_128.rs
@@ -4,6 +4,47 @@ use crate::multimixer_128::{multimixer_128, BLOCK_SIZE, DIGEST_SIZE};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic = "Message must be non-empty !"]
+fn test_empty_key_and_msg() {
+    let mut dig = [0u8; DIGEST_SIZE];
+    multimixer_128(&[], &[], &mut dig);
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic = "Both key and message must be of equal byte length !"]
+fn test_empty_key_and_nonempty_msg() {
+    let msg = [0u8; BLOCK_SIZE];
+    let mut dig = [0u8; DIGEST_SIZE];
+    multimixer_128(&[], &msg, &mut dig);
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic = "Key/ Message byte length must be a multiple of block size i.e. 32 -bytes !"]
+fn test_unsupported_msg_len() {
+    const MIN_MSG_LEN: usize = 1;
+    const MAX_MSG_LEN: usize = BLOCK_SIZE * 2;
+
+    let mut dig = [0u8; DIGEST_SIZE];
+    let mut mlen = MIN_MSG_LEN;
+
+    while mlen <= MAX_MSG_LEN {
+        let key = vec![0x0fu8; mlen];
+        let msg = vec![0xf0u8; mlen];
+
+        multimixer_128(&key, &msg, &mut dig);
+
+        mlen = if (mlen + 1) % BLOCK_SIZE == 0 {
+            mlen + 2
+        } else {
+            mlen + 1
+        };
+    }
+}
+
 #[test]
 fn test_known_answer_tests() {
     const FILE: &str = "./multimixer_128.kat";


### PR DESCRIPTION
Whenever possible make functions `const fn` - compile-time evaluable functions. Read more @ https://doc.rust-lang.org/reference/const_eval.html#const-functions.