### PR TITLE
Bump `criterion-cycles-per-byte` to Valid Git Commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ criterion = "=0.5.1"
 static_assertions = "1.1.0"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64", target_arch = "loongarch64"))'.dev-dependencies]
-criterion-cycles-per-byte = {git = "https://github.com/itzmeanjan/criterion-cycles-per-byte", rev = "d2f5bf863"}
+criterion-cycles-per-byte = {git = "https://github.com/itzmeanjan/criterion-cycles-per-byte", rev = "63edc6b46"}
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multimixer-128"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Anjan Roy <hello@itzmeanjan.in>"]
 description = "Universal Keyed Hashing Based on Integer Multiplication"

--- a/README.md
+++ b/README.md
@@ -153,12 +153,12 @@ Using $Multimixer_{128}$ hasher API is pretty straight-forward.
 [dependencies]
 multimixer-128 = { git = "https://github.com/itzmeanjan/multimixer-128" }
 # or
-multimixer-128 = "0.1.2"
+multimixer-128 = "0.1.3"
 
 # In case you're also interested in using f_128, the public function of multimixer-128,
 # enable `internal` feature-gate of this crate.
 #
-# multimixer-128 = { version = "0.1.2", features = "internal" }
+# multimixer-128 = { version = "0.1.3", features = "internal" }
 ```
 
 2) Get non-zero, equal length key and message s.t. their byte length is a multiple of block size (= 32 -bytes), as input.


### PR DESCRIPTION
Use correct commit hash for git-based dependency `criterion-cycles-per-byte`.
